### PR TITLE
Add TTL support for LRUCache

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,5 +1,7 @@
+import asyncio
 import pytest
 from data_ingestion.py.caching import LRUCache
+
 
 @pytest.mark.asyncio
 async def test_cache_capacity():
@@ -15,6 +17,7 @@ async def test_cache_capacity():
     assert await cache.get("b") == 2
     assert await cache.get("c") == 3
 
+
 @pytest.mark.asyncio
 async def test_cache_lru():
     """
@@ -29,3 +32,24 @@ async def test_cache_lru():
     assert await cache.get("b") is None
     assert await cache.get("a") == 1
     assert await cache.get("c") == 3
+
+
+@pytest.mark.asyncio
+async def test_cache_ttl_expiration():
+    """確保 TTL 到期後會自動刪除快取項目。"""
+    cache = LRUCache(capacity=2, ttl=0.1)
+    await cache.set("a", 1)
+    await asyncio.sleep(0.15)
+
+    assert await cache.get("a") is None
+    assert "a" not in cache
+
+
+@pytest.mark.asyncio
+async def test_cache_ttl_not_expired():
+    """確認在 TTL 未到期前能夠取得資料。"""
+    cache = LRUCache(capacity=2, ttl=0.2)
+    await cache.set("a", 1)
+    await asyncio.sleep(0.1)
+
+    assert await cache.get("a") == 1


### PR DESCRIPTION
## Summary
- enhance `LRUCache` with optional TTL support
- store insertion timestamps and expire entries when TTL elapsed
- verify expiration logic in new tests

## Testing
- `flake8 data_ingestion/py/caching.py tests/test_caching.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875201f7c84832fa8ce8db9c17186d9