### PR TITLE
Fix embargo logic in purged_k_fold

### DIFF
--- a/data_processing/cross_validation.py
+++ b/data_processing/cross_validation.py
@@ -2,21 +2,30 @@ from sklearn.model_selection import KFold
 
 def purged_k_fold(n_splits: int, n_samples: int, embargo: int):
     """
-    Purged K-Fold Cross-Validation.
+    Purged K-Fold Cross-Validation。
 
     Args:
         n_splits: The number of folds.
         n_samples: The number of samples.
-        embargo: The number of samples to purge after the test set.
+        embargo: 在測試區段前後需排除的樣本數。
 
     Yields:
         The train and test indices for each fold.
     """
     kf = KFold(n_splits=n_splits)
     for train_index, test_index in kf.split(range(n_samples)):
-        # Purge samples after the test set
+        # 測試集範圍
+        test_start = test_index[0]
         test_end = test_index[-1]
-        purge_start = test_end + 1
-        purge_end = purge_start + embargo
-        purged_train_index = [i for i in train_index if i < test_index[0] or i > purge_end]
+
+        # 前後禁入範圍計算
+        before_start = max(0, test_start - embargo)
+        before_end = test_start - 1
+        after_start = test_end + 1
+        after_end = min(n_samples - 1, test_end + embargo)
+
+        # 建立需排除的索引集合
+        embargo_indices = set(range(before_start, before_end + 1)) | set(range(after_start, after_end + 1))
+
+        purged_train_index = [i for i in train_index if i not in embargo_indices]
         yield purged_train_index, test_index

--- a/tests/data_processing/test_cross_validation.py
+++ b/tests/data_processing/test_cross_validation.py
@@ -1,0 +1,29 @@
+import unittest
+from data_processing.cross_validation import purged_k_fold
+
+class TestPurgedKFold(unittest.TestCase):
+    def test_embargo_before_and_after(self):
+        splits = list(purged_k_fold(n_splits=3, n_samples=12, embargo=2))
+
+        # Fold 0
+        train0, test0 = splits[0]
+        self.assertNotIn(4, train0)
+        self.assertNotIn(5, train0)
+        self.assertTrue(all(idx >= 6 for idx in train0))
+
+        # Fold 1
+        train1, test1 = splits[1]
+        self.assertNotIn(2, train1)
+        self.assertNotIn(3, train1)
+        self.assertNotIn(8, train1)
+        self.assertNotIn(9, train1)
+        self.assertEqual(train1, [0, 1, 10, 11])
+
+        # Fold 2
+        train2, test2 = splits[2]
+        self.assertNotIn(6, train2)
+        self.assertNotIn(7, train2)
+        self.assertTrue(all(idx <= 5 for idx in train2))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- enforce embargo before and after test folds in cross validation
- test that the indices around the test set are removed

## Testing
- `flake8 | head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875242c2e10832f9cffa649ad426900