### PR TITLE
Add adaptive multi-level rate limiting

### DIFF
--- a/data_ingestion/py/api_client.py
+++ b/data_ingestion/py/api_client.py
@@ -1,6 +1,7 @@
 import httpx
 import asyncio
 from tenacity import retry, wait_random_exponential, stop_after_attempt
+from data_ingestion.py.rate_limiter import RateLimiter
 
 
 class ApiClient:
@@ -8,7 +9,12 @@ class ApiClient:
     A simple asynchronous API client with retry logic.
     """
 
-    def __init__(self, base_url: str):
+    def __init__(
+        self,
+        base_url: str,
+        limiters: dict[str, RateLimiter] | None = None,
+        default_limiter: RateLimiter | None = None,
+    ):
         """初始化 ApiClient。
 
         Args:
@@ -16,6 +22,8 @@ class ApiClient:
         """
         self.base_url = base_url
         self.session: httpx.AsyncClient | None = None
+        self.limiters = limiters or {}
+        self.default_limiter = default_limiter
 
     async def __aenter__(self):
         """建立並回傳非同步 HTTP session。"""
@@ -31,7 +39,7 @@ class ApiClient:
         wait=wait_random_exponential(min=1, max=60),
         stop=stop_after_attempt(6),
     )
-    async def call_api(self, endpoint: str, params: dict = None):
+    async def call_api(self, endpoint: str, params: dict | None = None):
         """
         Calls an API endpoint asynchronously.
 
@@ -44,14 +52,24 @@ class ApiClient:
         """
         if self.session is None:
             self.session = httpx.AsyncClient()
+        limiter = self.limiters.get(endpoint, self.default_limiter)
+        if limiter:
+            await limiter.acquire()
         url = f"{self.base_url}/{endpoint}"
         try:
             response = await self.session.get(url, params=params)
             response.raise_for_status()
+            if limiter:
+                limiter.record_failure()
             return response.json()
         except httpx.HTTPStatusError as e:
-            if e.response.status_code == 429:
+            if limiter and e.response.status_code == 429:
                 retry_after = int(e.response.headers.get("Retry-After", 0))
                 if retry_after > 0:
                     await asyncio.sleep(retry_after)
+                limiter.record_failure(status_code=429)
             raise e
+        except httpx.TimeoutException:
+            if limiter:
+                limiter.record_failure(timeout=True)
+            raise

--- a/data_ingestion/py/rate_limiter.py
+++ b/data_ingestion/py/rate_limiter.py
@@ -4,8 +4,26 @@ import time
 import yaml
 
 
+class _TokenBucket:
+    """簡易 Token Bucket 實作，供內部使用。"""
+
+    def __init__(self, calls: int, period: float, burst: int) -> None:
+        self.calls = calls
+        self.period = period
+        self.burst = burst
+        self.tokens = float(burst)
+        self.last_checked = time.monotonic()
+
+    def refill(self) -> None:
+        now = time.monotonic()
+        elapsed = now - self.last_checked
+        rate = self.calls / self.period
+        self.tokens = min(self.burst, self.tokens + elapsed * rate)
+        self.last_checked = now
+
+
 class RateLimiter:
-    """非同步 Token Bucket 速率限制器，支援動態重新載入設定。"""
+    """非同步 Token Bucket 速率限制器，支援多組速限與動態調整。"""
 
     def __init__(
         self,
@@ -13,42 +31,55 @@ class RateLimiter:
         period: float,
         burst: int | None = None,
         *,
+        additional_limits: list[tuple[int, float, int]] | None = None,
         api_key: str | None = None,
         endpoint: str | None = None,
         config_path: str | None = None,
+        fail_threshold: int = 3,
     ) -> None:
-        self.calls = calls
-        self.period = period
-        self.burst = burst if burst is not None else calls
         self.api_key = api_key
         self.endpoint = endpoint
         self.config_path = config_path
+        self.fail_threshold = fail_threshold
+        self.fail_count = 0
 
         self._lock = asyncio.Lock()
-        self._tokens = float(self.burst)
-        self._last_checked = time.monotonic()
+        first_burst = burst if burst is not None else calls
+        self.buckets = [_TokenBucket(calls, period, first_burst)]
+        if additional_limits:
+            for c, p, b in additional_limits:
+                self.buckets.append(_TokenBucket(c, p, b))
+
         self._config_mtime = None
         if config_path and os.path.exists(config_path):
             self._config_mtime = os.path.getmtime(config_path)
+        self._update_attrs()
+
+    def _update_attrs(self) -> None:
+        """同步主要參數供外部存取。"""
+        main = self.buckets[0]
+        self.calls = main.calls
+        self.period = main.period
+        self.burst = main.burst
 
     async def acquire(self):
-        """等待直到可執行下一次請求，同時檢查設定是否更新。"""
+        """等待直到所有速限都允許執行下一次請求。"""
         while True:
             async with self._lock:
                 self._reload_if_needed()
                 self._refill_tokens()
-                if self._tokens >= 1:
-                    self._tokens -= 1
+                if all(b.tokens >= 1 for b in self.buckets):
+                    for b in self.buckets:
+                        b.tokens -= 1
                     return
-                wait_time = (1 - self._tokens) * self.period / self.calls
+                wait_time = max(
+                    (1 - b.tokens) * b.period / b.calls for b in self.buckets
+                )
             await asyncio.sleep(wait_time)
 
     def _refill_tokens(self) -> None:
-        now = time.monotonic()
-        elapsed = now - self._last_checked
-        rate = self.calls / self.period
-        self._tokens = min(self.burst, self._tokens + elapsed * rate)
-        self._last_checked = now
+        for bucket in self.buckets:
+            bucket.refill()
 
     def _reload_if_needed(self) -> None:
         if not self.config_path:
@@ -57,23 +88,50 @@ class RateLimiter:
             mtime = os.path.getmtime(self.config_path)
         except FileNotFoundError:
             return
-        if self._config_mtime is not None and mtime == self._config_mtime:
-            return
+        reload_needed = self._config_mtime is None or mtime != self._config_mtime
+        if not reload_needed:
+            # 檔案時間未變化仍嘗試讀取，以避免檔案系統解析度不足
+            pass
         self._config_mtime = mtime
         with open(self.config_path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
 
-        params: dict = {}
+        configs: list[dict] = []
+        if "global" in data:
+            configs.append(data["global"])
         if self.api_key:
-            params.update(data.get("api_keys", {}).get(self.api_key, {}))
+            configs.append(data.get("api_keys", {}).get(self.api_key, {}))
         if self.endpoint:
-            params.update(data.get("endpoints", {}).get(self.endpoint, {}))
+            configs.append(data.get("endpoints", {}).get(self.endpoint, {}))
 
-        self.calls = params.get("calls", self.calls)
-        self.period = params.get("period", self.period)
-        self.burst = params.get("burst", self.burst)
-        self._tokens = min(self.burst, self._tokens)
-        self._last_checked = time.monotonic()
+        if configs:
+            self.buckets = [
+                _TokenBucket(
+                    c.get("calls", 1),
+                    c.get("period", 1.0),
+                    c.get("burst", c.get("calls", 1)),
+                )
+                for c in configs
+            ]
+            self._update_attrs()
+
+    def record_failure(
+        self, *, status_code: int | None = None, timeout: bool = False
+    ) -> None:
+        """紀錄失敗事件並在達到門檻時降低速率。"""
+
+        if status_code == 429 or timeout:
+            self.fail_count += 1
+        else:
+            self.fail_count = 0
+
+        if self.fail_count >= self.fail_threshold:
+            for b in self.buckets:
+                b.calls = max(1, int(b.calls * 0.8))
+                b.burst = max(1, int(b.burst * 0.8))
+                b.tokens = min(b.tokens, b.burst)
+            self.fail_count = 0
+            self._update_attrs()
 
     @classmethod
     def from_config(
@@ -89,17 +147,47 @@ class RateLimiter:
         with open(config_path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
 
-        params: dict = {}
-        params.update(data.get("api_keys", {}).get(api_key, {}))
-        params.update(data.get("endpoints", {}).get(endpoint, {}))
+        limits: list[tuple[int, float, int]] = []
 
-        calls = params.get("calls", 1)
-        period = params.get("period", 1.0)
-        burst = params.get("burst", calls)
+        global_cfg = data.get("global")
+        if global_cfg:
+            limits.append(
+                (
+                    global_cfg.get("calls", 1),
+                    global_cfg.get("period", 1.0),
+                    global_cfg.get("burst", global_cfg.get("calls", 1)),
+                )
+            )
+
+        key_cfg = data.get("api_keys", {}).get(api_key, {})
+        ep_cfg = data.get("endpoints", {}).get(endpoint, {})
+
+        calls = ep_cfg.get("calls", key_cfg.get("calls", 1))
+        period = ep_cfg.get("period", key_cfg.get("period", 1.0))
+        burst = ep_cfg.get("burst", key_cfg.get("burst", calls))
+
+        if key_cfg:
+            limits.append(
+                (
+                    key_cfg.get("calls", 1),
+                    key_cfg.get("period", 1.0),
+                    key_cfg.get("burst", key_cfg.get("calls", 1)),
+                )
+            )
+        if ep_cfg:
+            limits.append(
+                (
+                    ep_cfg.get("calls", 1),
+                    ep_cfg.get("period", 1.0),
+                    ep_cfg.get("burst", ep_cfg.get("calls", 1)),
+                )
+            )
+
         return cls(
             calls=calls,
             period=period,
             burst=burst,
+            additional_limits=limits,
             api_key=api_key,
             endpoint=endpoint,
             config_path=config_path,

--- a/rate_limits.yml
+++ b/rate_limits.yml
@@ -1,3 +1,7 @@
+global:
+  calls: 100
+  period: 60
+  burst: 100
 api_keys:
   default:
     calls: 5

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,6 +1,7 @@
 import pytest
 from httpx import Response
 from data_ingestion.py.api_client import ApiClient
+from data_ingestion.py.rate_limiter import RateLimiter
 
 
 @pytest.mark.asyncio
@@ -15,7 +16,8 @@ async def test_call_api_success(httpx_mock):
         url=f"{base_url}/{endpoint}",
         json=expected_response,
     )
-    async with ApiClient(base_url=base_url) as api_client:
+    limiter = RateLimiter(calls=2, period=1)
+    async with ApiClient(base_url=base_url, limiters={endpoint: limiter}) as api_client:
         response = await api_client.call_api(endpoint)
     assert response == expected_response
 
@@ -34,7 +36,8 @@ async def test_call_api_retry(httpx_mock):
         url=f"{base_url}/{endpoint}",
         json={"data": "success"},
     )
-    async with ApiClient(base_url=base_url) as api_client:
+    limiter = RateLimiter(calls=2, period=1, fail_threshold=1)
+    async with ApiClient(base_url=base_url, limiters={endpoint: limiter}) as api_client:
         response = await api_client.call_api(endpoint)
         assert response == {"data": "success"}
         assert len(httpx_mock.get_requests()) == 2

--- a/tests/test_data_source.py
+++ b/tests/test_data_source.py
@@ -12,6 +12,7 @@ async def test_read_from_cache():
     Tests that data is read from the cache if it exists.
     """
     api_client = AsyncMock(spec=ApiClient)
+    api_client.limiters = {}
     rate_limiter = MagicMock(spec=RateLimiter)
     cache = MagicMock(spec=LRUCache)
     cache.get = AsyncMock()
@@ -20,7 +21,7 @@ async def test_read_from_cache():
         api_client=api_client,
         rate_limiter=rate_limiter,
         cache=cache,
-        endpoint=endpoint
+        endpoint=endpoint,
     )
     params = {"param": "value"}
     cache_key = f"{endpoint}:{tuple(sorted(params.items()))}"
@@ -41,6 +42,7 @@ async def test_read_from_api():
     Tests that data is read from the API if it's not in the cache.
     """
     api_client = AsyncMock(spec=ApiClient)
+    api_client.limiters = {}
     rate_limiter = MagicMock(spec=RateLimiter)
     cache = MagicMock(spec=LRUCache)
     cache.get = AsyncMock()
@@ -62,6 +64,6 @@ async def test_read_from_api():
 
     assert data == expected_data
     cache.get.assert_called_once_with(cache_key)
-    rate_limiter.acquire.assert_called_once()
+    rate_limiter.acquire.assert_not_called()
     api_client.call_api.assert_called_once_with(endpoint, params)
     cache.set.assert_called_once_with(cache_key, expected_data)


### PR DESCRIPTION
## Summary
- support multiple rate limits (global/key/endpoint) in `RateLimiter`
- auto-register limiters in `ApiClient` and `APIDataSource`
- adaptive throttling when many 429 or timeouts occur
- update configuration and example tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875a32852d8832f89002f2f19ee6f2a