### PR TITLE
Implement FastAPI proxy and integrate with data source

### DIFF
--- a/data_ingestion/proxy/__init__.py
+++ b/data_ingestion/proxy/__init__.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import logging
+from fastapi import FastAPI, Request
+from fastapi.responses import Response
+import httpx
+from tenacity import retry, wait_random_exponential, stop_after_attempt
+
+from data_ingestion.py.rate_limiter import RateLimiter
+from data_ingestion.py.caching import LRUCache
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_proxy_app(
+    target_base_url: str,
+    *,
+    rate_limiter: RateLimiter | None = None,
+    cache: LRUCache | None = None,
+) -> FastAPI:
+    """建立反向 proxy FastAPI 應用程式。"""
+
+    limiter = rate_limiter or RateLimiter(calls=5, period=1)
+    proxy_cache = cache or LRUCache(capacity=128, ttl=60)
+    app = FastAPI()
+    client = httpx.AsyncClient(base_url=target_base_url)
+
+    @retry(wait=wait_random_exponential(min=1, max=4), stop=stop_after_attempt(3))
+    async def _forward(method: str, url: str, params: dict) -> httpx.Response:
+        resp = await client.request(method, url, params=params)
+        resp.raise_for_status()
+        return resp
+
+    @app.api_route("/{path:path}", methods=["GET"])  # 簡化僅支援 GET
+    async def proxy(path: str, request: Request) -> Response:
+        await limiter.acquire()
+        cache_key = f"{path}?{request.query_params}"
+        cached = await proxy_cache.get(cache_key)
+        if cached is not None:
+            logger.info("cache hit %s", cache_key)
+            return Response(
+                content=cached["content"],
+                status_code=cached["status"],
+                media_type=cached["media_type"],
+            )
+        try:
+            resp = await _forward(
+                request.method,
+                f"/{path}",
+                dict(request.query_params),
+            )
+        except httpx.HTTPError as exc:  # pragma: no cover - 轉換成 502
+            logger.error("proxy error: %s", exc)
+            return Response(content=str(exc), status_code=502)
+        logger.info("forward %s", request.url.path)
+        await proxy_cache.set(
+            cache_key,
+            {
+                "content": resp.content,
+                "status": resp.status_code,
+                "media_type": resp.headers.get("content-type"),
+            },
+        )
+        return Response(
+            content=resp.content,
+            status_code=resp.status_code,
+            media_type=resp.headers.get("content-type"),
+        )
+
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:
+        await client.aclose()
+
+    return app

--- a/data_ingestion/py/api_client.py
+++ b/data_ingestion/py/api_client.py
@@ -14,13 +14,16 @@ class ApiClient:
         base_url: str,
         limiters: dict[str, RateLimiter] | None = None,
         default_limiter: RateLimiter | None = None,
+        proxy_base_url: str | None = None,
     ):
         """初始化 ApiClient。
 
         Args:
             base_url: API 的基底網址
+            proxy_base_url: 若提供則透過此 proxy 轉發請求
         """
         self.base_url = base_url
+        self.proxy_base_url = proxy_base_url
         self.session: httpx.AsyncClient | None = None
         self.limiters = limiters or {}
         self.default_limiter = default_limiter
@@ -56,6 +59,8 @@ class ApiClient:
         if limiter:
             await limiter.acquire()
         url = f"{self.base_url}/{endpoint}"
+        if self.proxy_base_url:
+            url = f"{self.proxy_base_url}/{endpoint}"
         try:
             response = await self.session.get(url, params=params)
             response.raise_for_status()

--- a/example.py
+++ b/example.py
@@ -12,9 +12,10 @@ async def main():
     # Configure the cache: 100 items capacity
     cache = LRUCache(capacity=100)
 
-    # 使用 context manager 建立 API client
+    # 使用 context manager 建立 API client，透過 proxy 轉發
     async with ApiClient(
         base_url="https://jsonplaceholder.typicode.com",
+        proxy_base_url="http://localhost:8000",
     ) as api_client:
         api_source = APIDataSource(
             api_client=api_client,

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pytest-asyncio
 pytest-httpx
 flake8
 pyyaml
+fastapi

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -41,3 +41,18 @@ async def test_call_api_retry(httpx_mock):
         response = await api_client.call_api(endpoint)
         assert response == {"data": "success"}
         assert len(httpx_mock.get_requests()) == 2
+
+
+@pytest.mark.asyncio
+async def test_call_api_with_proxy(httpx_mock):
+    base_url = "http://target.com"
+    proxy_url = "http://proxy"
+    endpoint = "foo"
+    httpx_mock.add_response(url=f"{proxy_url}/{endpoint}", json={"ok": True})
+    async with ApiClient(
+        base_url=base_url,
+        proxy_base_url=proxy_url,
+    ) as client:
+        resp = await client.call_api(endpoint)
+        assert resp == {"ok": True}
+        assert len(httpx_mock.get_requests()) == 1

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,43 @@
+import time
+import pytest
+import httpx
+from data_ingestion.proxy import create_proxy_app
+from data_ingestion.py.rate_limiter import RateLimiter
+from data_ingestion.py.caching import LRUCache
+
+
+@pytest.mark.asyncio
+async def test_proxy_forwarding(httpx_mock):
+    target_url = "http://remote.com"
+    app = create_proxy_app(target_url)
+    httpx_mock.add_response(url=f"{target_url}/data", json={"a": 1})
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://proxy"
+    ) as client:
+        resp = await client.get("/data")
+        assert resp.status_code == 200
+        assert resp.json() == {"a": 1}
+        assert len(httpx_mock.get_requests()) == 1
+
+
+@pytest.mark.asyncio
+async def test_proxy_rate_limit(httpx_mock):
+    limiter = RateLimiter(calls=1, period=0.5)
+    cache = LRUCache(capacity=1, ttl=0)
+    app = create_proxy_app(
+        "http://remote.com",
+        rate_limiter=limiter,
+        cache=cache,
+    )
+    httpx_mock.add_response(url="http://remote.com/data", json={"a": 1})
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://proxy"
+    ) as client:
+        await client.get("/data")
+        httpx_mock.add_response(url="http://remote.com/data", json={"a": 2})
+        start = time.monotonic()
+        await client.get("/data")
+        delta = time.monotonic() - start
+        assert delta >= 0.49


### PR DESCRIPTION
## Summary
- add `data_ingestion.proxy` module providing a simple reverse proxy using FastAPI
- allow `ApiClient` to forward requests via proxy
- update example to show using the proxy
- add tests for proxy behaviour and proxy option in `ApiClient`
- include FastAPI in requirements

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875a94cfba4832f9980fcdc9e81cac7