### PR TITLE
Add batch API call with concurrency limit

### DIFF
--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,4 +1,6 @@
+import asyncio
 import pytest
+import httpx
 from httpx import Response
 from data_ingestion.py.api_client import ApiClient
 from data_ingestion.py.rate_limiter import RateLimiter
@@ -56,3 +58,34 @@ async def test_call_api_with_proxy(httpx_mock):
         resp = await client.call_api(endpoint)
         assert resp == {"ok": True}
         assert len(httpx_mock.get_requests()) == 1
+
+
+@pytest.mark.asyncio
+async def test_call_batch_with_semaphore():
+    """確認批次呼叫會遵守併發上限。"""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    active = 0
+    peak = 0
+
+    @app.get("/{name}")
+    async def handle(name: str):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.05)
+        active -= 1
+        return {"name": name}
+
+    transport = httpx.ASGITransport(app=app)
+    client = ApiClient(base_url="http://test", max_concurrency=2)
+    client.session = httpx.AsyncClient(transport=transport, base_url="http://test")
+
+    endpoints = [(f"ep{i}", {}) for i in range(5)]
+    results = await client.call_batch(endpoints)
+
+    await client.session.aclose()
+
+    assert [r["name"] for r in results] == [f"ep{i}" for i in range(5)]
+    assert peak <= 2


### PR DESCRIPTION
## Summary
- add semaphore-based concurrency control for `ApiClient`
- implement `call_batch` to execute multiple API calls in parallel
- test batch API call and concurrency limits

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875b056502c832fae0ecb9c3625f2fc