### PR TITLE
Add Prefect pipeline and scheduler docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,23 @@ python example.py
 pytest
 ```
 
+
+## 啟動排程器與註冊任務
+
+1. 安裝所有依賴：
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. 啟動 Prefect Orion 伺服器：
+   ```bash
+   prefect orion start
+   ```
+3. 建立並套用部署檔案：
+   ```bash
+   prefect deployment build pipelines/data_pipeline.py:data_pipeline_flow -n data-pipeline -q default
+   prefect deployment apply data_pipeline_flow-deployment.yaml
+   ```
+4. 啟動執行代理：
+   ```bash
+   prefect agent start -q default
+   ```

--- a/pipelines/data_pipeline.py
+++ b/pipelines/data_pipeline.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+import pandas as pd
+from prefect import flow, task, get_run_logger
+
+from data_processing.pipeline import Pipeline
+from data_processing.data_cleanser import DataCleanser
+from data_processing.feature_engineer import FeatureEngineer
+
+
+@task
+def run_pipeline(df: pd.DataFrame, steps: Iterable) -> pd.DataFrame:
+    """執行 Pipeline 並記錄時間與資料筆數"""
+    logger = get_run_logger()
+    pipeline = Pipeline(list(steps))
+    start = datetime.now()
+    result = pipeline.process(df)
+    duration = (datetime.now() - start).total_seconds()
+    logger.info(f"處理完成，共 {len(result)} rows，耗時 {duration:.2f}s")
+    return result
+
+
+@flow
+def data_pipeline_flow(df: pd.DataFrame) -> pd.DataFrame:
+    """範例 Prefect Flow"""
+    steps = [DataCleanser(), FeatureEngineer(features_to_create=["moving_average"])]
+    return run_pipeline(df, steps)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ flake8
 pyyaml
 fastapi
 
+prefect
 prometheus-client


### PR DESCRIPTION
## Summary
- create `pipelines` package with Prefect DAG example
- log runtime and row count inside Prefect task
- document how to start Prefect scheduler and register deployment
- include Prefect in requirements

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6875bd79f2dc832fb2bd3d204f4ff2da