### PR TITLE
Implement catalog and auto tiering

### DIFF
--- a/data_storage/__init__.py
+++ b/data_storage/__init__.py
@@ -7,6 +7,7 @@ from .storage_backend import (
     S3Cold,
     HybridStorageManager,
 )
+from .catalog import Catalog, CatalogEntry
 
 __all__ = [
     "StorageBackend",
@@ -14,4 +15,6 @@ __all__ = [
     "TimescaleWarm",
     "S3Cold",
     "HybridStorageManager",
+    "Catalog",
+    "CatalogEntry",
 ]

--- a/data_storage/catalog.py
+++ b/data_storage/catalog.py
@@ -1,0 +1,66 @@
+import sqlite3
+from dataclasses import dataclass
+
+
+@dataclass
+class CatalogEntry:
+    """Catalog 資料結構。"""
+
+    table_name: str
+    tier: str
+    location: str
+    schema_hash: str
+
+
+class Catalog:
+    """使用 SQLite 紀錄資料表所在層級與 schema。"""
+
+    def __init__(self, db_path: str = ":memory:") -> None:
+        self.conn = sqlite3.connect(db_path)
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS catalog (
+                table_name TEXT PRIMARY KEY,
+                tier TEXT,
+                location TEXT,
+                schema_hash TEXT
+            )
+            """
+        )
+        self.conn.commit()
+
+    def upsert(self, entry: CatalogEntry) -> None:
+        """新增或更新表格資訊。"""
+        with self.conn:
+            self.conn.execute(
+                """
+                INSERT INTO catalog (table_name, tier, location, schema_hash)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(table_name) DO UPDATE SET
+                    tier=excluded.tier,
+                    location=excluded.location,
+                    schema_hash=excluded.schema_hash
+                """,
+                (entry.table_name, entry.tier, entry.location, entry.schema_hash),
+            )
+
+    def update_tier(self, table_name: str, tier: str, location: str) -> None:
+        """更新表格所在層級。"""
+        with self.conn:
+            self.conn.execute(
+                "UPDATE catalog SET tier=?, location=? WHERE table_name=?",
+                (tier, location, table_name),
+            )
+
+    def get(self, table_name: str) -> CatalogEntry | None:
+        cur = self.conn.execute(
+            (
+                "SELECT table_name, tier, location, schema_hash "
+                "FROM catalog WHERE table_name=?"
+            ),
+            (table_name,),
+        )
+        row = cur.fetchone()
+        if row:
+            return CatalogEntry(*row)
+        return None

--- a/tests/test_auto_tiering.py
+++ b/tests/test_auto_tiering.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from data_storage import HybridStorageManager, Catalog
+
+
+def test_auto_migration_hot_to_warm_and_cold():
+    catalog = Catalog()
+    manager = HybridStorageManager(catalog=catalog, hot_capacity=1, warm_capacity=1)
+
+    df1 = pd.DataFrame({"a": [1]})
+    df2 = pd.DataFrame({"b": [2]})
+    df3 = pd.DataFrame({"c": [3]})
+
+    manager.write(df1, "t1", tier="hot")
+    # writing second table triggers migration of t1 to warm
+    manager.write(df2, "t2", tier="hot")
+    assert catalog.get("t1").tier == "warm"
+
+    manager.write(df3, "t3", tier="hot")
+    # now t2 should move to warm and t1 move to cold due to warm capacity
+    assert catalog.get("t2").tier == "warm"
+    assert catalog.get("t1").tier == "cold"

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from data_storage import HybridStorageManager, Catalog
+
+
+def test_catalog_updates_on_write():
+    catalog = Catalog()
+    manager = HybridStorageManager(catalog=catalog)
+    df = pd.DataFrame({"a": [1]})
+    manager.write(df, "tbl1", tier="hot")
+
+    entry = catalog.get("tbl1")
+    assert entry is not None
+    assert entry.tier == "hot"
+
+
+def test_catalog_updates_on_migrate():
+    catalog = Catalog()
+    manager = HybridStorageManager(catalog=catalog)
+    df = pd.DataFrame({"a": [1]})
+    manager.write(df, "tbl2", tier="hot")
+    manager.migrate("tbl2", "hot", "cold")
+
+    entry = catalog.get("tbl2")
+    assert entry is not None
+    assert entry.tier == "cold"


### PR DESCRIPTION
## Summary
- add SQLite catalog to record table tier info
- integrate catalog with storage backend and auto LRU migration
- export Catalog from package
- test catalog update and automatic tier migration

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875c45e09f8832f958c758620621e5e