### PR TITLE
Add CI workflow and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 設定 Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: 安裝依賴
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8 pytest pytest-cov
+      - name: 執行 Flake8
+        run: flake8 .
+      - name: 執行 pytest
+        run: pytest --cov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Data-Fetcher
 
+若要檢視 CI 狀態徽章，請將下列網址中的 `<YOUR_GITHUB_ACCOUNT>` 替換成你的 GitHub 帳號：
+
+[![CI](https://github.com/<YOUR_GITHUB_ACCOUNT>/Data-Fetcher/actions/workflows/ci.yml/badge.svg)](https://github.com/<YOUR_GITHUB_ACCOUNT>/Data-Fetcher/actions/workflows/ci.yml)
+
 此專案提供非同步 API 資料擷取與簡易處理管線，方便在 ZXQuant 或其他回測系統中使用。
 
 ## 安裝


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run flake8 and pytest with coverage
- show how to check CI status badge in README

## Testing
- `flake8 && echo "flake8 success"`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875c7b62500832faf8d3adeec157c49