### PR TITLE
Add coverage config & new storage tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=data_ingestion --cov=data_processing --cov-fail-under=80

--- a/tests/test_semaphore.py
+++ b/tests/test_semaphore.py
@@ -1,0 +1,33 @@
+import asyncio
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from data_ingestion.py.api_client import ApiClient
+
+
+@pytest.mark.asyncio
+async def test_call_api_semaphore():
+    app = FastAPI()
+    active = 0
+    peak = 0
+
+    @app.get("/{name}")
+    async def handle(name: str):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.05)
+        active -= 1
+        return {"name": name}
+
+    transport = httpx.ASGITransport(app=app)
+    client = ApiClient(base_url="http://test", max_concurrency=1)
+    client.session = httpx.AsyncClient(transport=transport, base_url="http://test")
+
+    endpoints = ["a", "b", "c"]
+    results = await asyncio.gather(*[client.call_api(ep) for ep in endpoints])
+    await client.session.aclose()
+
+    assert [r["name"] for r in results] == endpoints
+    assert peak <= 1

--- a/tests/test_storage_backend_basic.py
+++ b/tests/test_storage_backend_basic.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import pytest
+
+from data_storage import DuckHot, TimescaleWarm, S3Cold, HybridStorageManager
+
+
+@pytest.mark.parametrize("backend_cls", [DuckHot, TimescaleWarm, S3Cold])
+def test_backend_write_read_delete(backend_cls):
+    backend = backend_cls()
+    df = pd.DataFrame({"a": [1, 2]})
+    backend.write(df, "tbl")
+    result = backend.read("tbl")
+    pd.testing.assert_frame_equal(result, df)
+
+    backend.delete("tbl")
+    with pytest.raises(KeyError):
+        backend.read("tbl")
+
+
+def test_manager_invalid_tier():
+    manager = HybridStorageManager()
+    df = pd.DataFrame({"a": [1]})
+    with pytest.raises(ValueError):
+        manager.write(df, "tbl", tier="unknown")
+
+
+def test_manager_read_missing():
+    manager = HybridStorageManager()
+    with pytest.raises(KeyError):
+        manager.read("missing")


### PR DESCRIPTION
## Summary
- enable coverage checking in `pytest.ini`
- test semaphore behavior in `ApiClient`
- add basic tests for storage backends and error cases

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875c94c6d68832f81fdb633400deb94