### PR TITLE
Update docs for rate limiting and storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,46 @@ pytest
    ```bash
    prefect agent start -q default
    ```
+
+## 速率限制設定檔
+
+`RateLimiter` 可透過 `rate_limits.yml` 讀取多組速率限制，格式如下：
+
+```yaml
+global:
+  calls: 100
+  period: 60
+  burst: 100
+api_keys:
+  default:
+    calls: 5
+    period: 1
+    burst: 5
+endpoints:
+  example:
+    calls: 10
+    period: 1
+    burst: 10
+```
+
+在程式中可使用 `RateLimiter.from_config("default", "example")` 建立實例，隨時重新載入檔案內容。
+
+## 啟動 Proxy 服務
+
+Proxy 透過 FastAPI 以及 `create_proxy_app()` 建立。使用 `uvicorn --factory` 啟動並指定目標 API：
+
+```bash
+uvicorn 'data_ingestion.proxy:create_proxy_app("https://api.example.com")' --factory --port 8000
+```
+
+建議 `fastapi>=0.110`、`uvicorn>=0.23`。
+
+## DAG 執行與儲存架構
+
+Prefect Flow `data_pipeline_flow` 可透過部署檔案觸發：
+
+```bash
+prefect deployment run data-pipeline
+```
+
+處理後的資料會存入 `HybridStorageManager` 管理的 Hot/Warm/Cold 層級，詳細說明請參考 [`docs/data_storage.md`](docs/data_storage.md)。

--- a/docs/data_storage.md
+++ b/docs/data_storage.md
@@ -1,0 +1,26 @@
+# 多層級儲存策略
+
+本專案採用 Hot、Warm、Cold 三層級架構，以取得效能與成本之平衡：
+
+- **Hot**：以記憶體或 Redis、DuckDB In-Memory 儲存，適用於 7 天內的即時查詢。
+- **Warm**：採用 TimescaleDB/PostgreSQL，適合 30~180 天的歷史資料與特徵工程。
+- **Cold**：將長期資料以 Parquet 存放在 S3 或 MinIO，可保留數年。
+
+`HybridStorageManager` 會根據資料表所在層級讀寫資料並在容量達到上限時自動下移：
+
+```python
+import pandas as pd
+from data_storage import HybridStorageManager
+
+manager = HybridStorageManager()
+
+# 寫入資料到 Hot tier
+manager.write(pd.DataFrame({'a': [1, 2]}), 'prices', tier='hot')
+
+# 讀取資料，未指定 tier 將自動從較熱的層級開始查詢
+recent = manager.read('prices')
+
+# 移動資料到 Cold tier
+manager.migrate('prices', 'hot', 'cold')
+```
+


### PR DESCRIPTION
## Summary
- update README with rate limit config, Proxy 啟動方式, DAG 執行與儲存架構說明
- add docs/data_storage.md summarizing hybrid storage strategy

## Testing
- No tests run since only docs were modified

------
https://chatgpt.com/codex/tasks/task_e_6875ca5cd9c4832fadb7e7bbacd77f87