### PR TITLE
Add docker compose with nginx proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "proxy.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ Proxy 透過 FastAPI 以及 `create_proxy_app()` 建立。使用 `uvicorn --fact
 uvicorn 'data_ingestion.proxy:create_proxy_app("https://api.example.com")' --factory --port 8000
 ```
 
+### Docker Compose 快速啟動
+
+倉庫內已提供 `docker-compose.yml` 及 `proxy/conf` 下的 NGINX 設定檔，
+可直接啟動 NGINX 與 FastAPI Proxy 組成的服務：
+
+```bash
+docker compose up --build
+```
+
+Nginx 會在本機的 80 連接埠對外服務，FastAPI 於容器內的 8000
+連接埠執行，可透過 `PROXY_TARGET` 環境變數調整轉發目標。
+
 建議 `fastapi>=0.110`、`uvicorn>=0.23`。
 
 ## DAG 執行與儲存架構

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.9'
+services:
+  app:
+    build: .
+    container_name: fastapi-proxy
+    environment:
+      - PROXY_TARGET=https://api.example.com
+    expose:
+      - "8000"
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - ./proxy/conf/nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "80:80"
+    depends_on:
+      - app

--- a/proxy/conf/nginx.conf
+++ b/proxy/conf/nginx.conf
@@ -1,0 +1,19 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+    upstream fastapi {
+        server app:8000;
+    }
+
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://fastapi;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+}

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -1,0 +1,6 @@
+import os
+from data_ingestion.proxy import create_proxy_app
+
+# 讀取目標 API URL，預設可修改為實際位址
+TARGET = os.environ.get("PROXY_TARGET", "https://api.example.com")
+app = create_proxy_app(TARGET)


### PR DESCRIPTION
## Summary
- add Dockerfile for proxy service
- add docker-compose.yml with nginx reverse proxy
- provide Nginx configuration in `proxy/conf`
- entry script `proxy/main.py`
- document how to start the stack

## Testing
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6875d05c0e7c832fa477dbb85d2beb1c