### PR TITLE
Add walk-forward CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ python example.py
 ```bash
 pytest
 ```
+## CLI 使用範例
+
+安裝完成後可透過 `zxq` 指令進行 Walk-Forward 切分：
+
+```bash
+zxq walk-forward 10 3 2 2
+```
+
+會輸出每一折的訓練與測試索引。
+
 
 
 ## 啟動排程器與註冊任務

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,7 @@
 max-line-length = 88
 extend-ignore = E203,W503
 
+
+[options.entry_points]
+console_scripts =
+    zxq=zxq.cli:main

--- a/zxq/cli.py
+++ b/zxq/cli.py
@@ -1,0 +1,35 @@
+import argparse
+from data_processing.cross_validation import walk_forward_split
+
+
+def _cmd_walk_forward(args: argparse.Namespace) -> None:
+    """執行 Walk-Forward 切分並列印索引。"""
+    for train_idx, test_idx in walk_forward_split(
+        args.samples,
+        args.train_size,
+        args.test_size,
+        args.step_size,
+    ):
+        print(train_idx, test_idx)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="zxq")
+    subparsers = parser.add_subparsers(dest="command")
+
+    wf = subparsers.add_parser("walk-forward", help="Walk-Forward 資料切分")
+    wf.add_argument("samples", type=int, help="總樣本數")
+    wf.add_argument("train_size", type=int, help="訓練集大小")
+    wf.add_argument("test_size", type=int, help="測試集大小")
+    wf.add_argument("step_size", type=int, help="步進大小")
+    wf.set_defaults(func=_cmd_walk_forward)
+
+    args = parser.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `zxq.cli` with walk-forward command
- register console entry point
- document CLI usage

## Testing
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6875d0600edc832f9c9b2e4459bc844a