### PR TITLE
Add zxq storage migrate command

### DIFF
--- a/docs/data_storage.md
+++ b/docs/data_storage.md
@@ -24,3 +24,13 @@ recent = manager.read('prices')
 manager.migrate('prices', 'hot', 'cold')
 ```
 
+
+## 指令操作範例
+
+透過 `zxq` 指令亦可移動資料表，例如：
+
+```bash
+zxq storage migrate --table prices --to warm
+```
+
+加入 `--dry-run` 參數則僅顯示預計動作而不實際執行。

--- a/zxq/__init__.py
+++ b/zxq/__init__.py
@@ -1,0 +1,5 @@
+"""ZXQuant 工具集。"""
+
+from .__main__ import main
+
+__all__ = ["main"]

--- a/zxq/__main__.py
+++ b/zxq/__main__.py
@@ -1,0 +1,40 @@
+"""zxq 指令列工具。"""
+
+import argparse
+from data_storage import HybridStorageManager
+
+
+def _cmd_storage_migrate(args: argparse.Namespace) -> None:
+    manager = HybridStorageManager()
+    entry = manager.catalog.get(args.table)
+    if entry is None:
+        raise SystemExit(f"找不到資料表 {args.table}")
+    if args.dry_run:
+        print(f"預計將 {args.table} 從 {entry.tier} 移至 {args.to}")
+    else:
+        manager.migrate(args.table, entry.tier, args.to)
+        print(f"已將 {args.table} 從 {entry.tier} 移至 {args.to}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="zxq")
+    subparsers = parser.add_subparsers(dest="command")
+
+    storage_parser = subparsers.add_parser("storage")
+    storage_sub = storage_parser.add_subparsers(dest="action")
+
+    migrate_parser = storage_sub.add_parser("migrate")
+    migrate_parser.add_argument("--table", required=True)
+    migrate_parser.add_argument("--to", required=True, choices=["hot", "warm", "cold"])
+    migrate_parser.add_argument("--dry-run", action="store_true")
+    migrate_parser.set_defaults(func=_cmd_storage_migrate)
+
+    args = parser.parse_args(argv)
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple `zxq` command line tool with `storage migrate`
- document how to use the new command in the storage guide

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875d063d198832fbf1c809f3f2c9dd6