### PR TITLE
Add metrics for storage migration

### DIFF
--- a/data_storage/storage_backend.py
+++ b/data_storage/storage_backend.py
@@ -6,7 +6,13 @@ from collections import deque
 import pandas as pd
 
 from .catalog import Catalog, CatalogEntry
-from metrics import STORAGE_WRITE_COUNTER, STORAGE_READ_COUNTER
+from metrics import (
+    STORAGE_WRITE_COUNTER,
+    STORAGE_READ_COUNTER,
+    MIGRATION_LATENCY_MS,
+    update_tier_hit_rate,
+)
+from time import perf_counter
 
 
 class StorageBackend(ABC):
@@ -165,6 +171,7 @@ class HybridStorageManager(StorageBackend):
             try:
                 result = backend.read(table)
                 STORAGE_READ_COUNTER.labels(tier=tier).inc()
+                update_tier_hit_rate()
                 return result
             except KeyError:
                 continue
@@ -175,10 +182,12 @@ class HybridStorageManager(StorageBackend):
             backend.delete(table)
 
     def migrate(self, table: str, src_tier: str, dst_tier: str) -> None:
+        start_time = perf_counter()
         src = self._backend_for(src_tier)
         dst = self._backend_for(dst_tier)
         df = src.read(table)
         STORAGE_READ_COUNTER.labels(tier=src_tier).inc()
+        update_tier_hit_rate()
         dst.write(df, table)
         STORAGE_WRITE_COUNTER.labels(tier=dst_tier).inc()
         src.delete(table)
@@ -196,3 +205,7 @@ class HybridStorageManager(StorageBackend):
             self._record_lru(self._hot_lru, table)
 
         self._check_capacity()
+        duration_ms = (perf_counter() - start_time) * 1000
+        MIGRATION_LATENCY_MS.labels(src_tier=src_tier, dst_tier=dst_tier).observe(
+            duration_ms
+        )

--- a/tests/test_storage_manager.py
+++ b/tests/test_storage_manager.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 from data_storage import HybridStorageManager
+from metrics import MIGRATION_LATENCY_MS, TIER_HIT_RATE
 
 
 def test_hot_write_and_read():
@@ -29,3 +30,34 @@ def test_cold_migration():
         manager.read("cold_tbl", tiers=["hot"])
     result = manager.read("cold_tbl", tiers=["cold"])
     pd.testing.assert_frame_equal(result, df)
+
+
+def test_migration_latency_histogram():
+    manager = HybridStorageManager()
+    df = pd.DataFrame({"d": [10]})
+    manager.write(df, "tbl_migrate", tier="hot")
+    before = sum(
+        b.get() for b in MIGRATION_LATENCY_MS.labels("hot", "warm")._buckets
+    )
+    manager.migrate("tbl_migrate", "hot", "warm")
+    after = sum(
+        b.get() for b in MIGRATION_LATENCY_MS.labels("hot", "warm")._buckets
+    )
+    assert after == before + 1
+
+
+def test_tier_hit_rate():
+    manager = HybridStorageManager()
+    df = pd.DataFrame({"e": [5]})
+    manager.write(df, "rate_tbl", tier="hot")
+    before_hot = TIER_HIT_RATE.labels(tier="hot")._value.get()
+    before_warm = TIER_HIT_RATE.labels(tier="warm")._value.get()
+    manager.read("rate_tbl")
+    after_hot = TIER_HIT_RATE.labels(tier="hot")._value.get()
+    assert after_hot > before_hot
+    manager.migrate("rate_tbl", "hot", "warm")
+    manager.read("rate_tbl", tiers=["warm"])
+    final_hot = TIER_HIT_RATE.labels(tier="hot")._value.get()
+    final_warm = TIER_HIT_RATE.labels(tier="warm")._value.get()
+    assert final_hot < after_hot
+    assert final_warm > before_warm


### PR DESCRIPTION
## Summary
- record migration latency in `HybridStorageManager.migrate`
- compute `tier_hit_rate` gauge when reads occur
- test new metrics

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875d065ca18832faec6676210c60eae