### PR TITLE
Add Grafana dashboards and Alertmanager rules

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -16,3 +16,22 @@ start_exporter(8000)  # 在 8000 埠口提供 /metrics
    - 表達式：`sum(rate(data_ingestion_429_total[1m])) > 100`
    - 評估頻率：1 分鐘
    - 觸發時可透過 Email 或其他通知管道告警。
+
+## Prometheus 與 Alertmanager
+
+1. 安裝 Prometheus，並在 `prometheus.yml` 中加入下列設定：
+
+   ```yaml
+   scrape_configs:
+     - job_name: data-fetcher
+       static_configs:
+         - targets: ['localhost:8000']
+   rule_files:
+     - monitoring/alert_rules.yml
+   ```
+2. Alertmanager 可直接匯入 `monitoring/alert_rules.yml` 取得預設警報條件。
+
+## 匯入 Grafana 儀表板
+
+1. 於 Grafana 的 **Import dashboard** 畫面選擇 `monitoring/grafana_data_fetcher.json`。
+2. 確認資料來源為前述 Prometheus。

--- a/monitoring/alert_rules.yml
+++ b/monitoring/alert_rules.yml
@@ -1,0 +1,17 @@
+groups:
+  - name: data-fetcher
+    rules:
+      - alert: High429Rate
+        expr: sum(rate(data_ingestion_429_total[1m])) > 100
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "429 錯誤率過高"
+      - alert: PipelineNotProcessing
+        expr: rate(data_processing_steps_total[5m]) == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "處理管線 5 分鐘內未執行"

--- a/monitoring/grafana_data_fetcher.json
+++ b/monitoring/grafana_data_fetcher.json
@@ -1,0 +1,29 @@
+{
+  "dashboard": {
+    "title": "Data Fetcher",
+    "panels": [
+      {
+        "type": "graph",
+        "title": "429 Rate",
+        "datasource": "Prometheus",
+        "targets": [
+          {
+            "expr": "sum(rate(data_ingestion_429_total[1m]))",
+            "legendFormat": "429 per sec"
+          }
+        ]
+      },
+      {
+        "type": "graph",
+        "title": "Processing Steps",
+        "datasource": "Prometheus",
+        "targets": [
+          {
+            "expr": "sum(rate(data_processing_steps_total[1m]))",
+            "legendFormat": "steps per sec"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add sample Alertmanager rules for checklist thresholds
- provide Grafana dashboard JSON template
- update monitoring docs with setup instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875d065cd2c832f8fd1952c54d05142