### PR TITLE
Remove duplicate entry_points section

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,13 +5,7 @@ extend-ignore = E203,W503
 
 [options]
 packages = find:
-
 [options.entry_points]
 console_scripts =
-    zxq = zxq:app
-
-
-[options.entry_points]
-console_scripts =
-    zxq=zxq.cli:main
+    zxq = zxq.cli:main
 


### PR DESCRIPTION
## Summary
- clean up duplicate `options.entry_points` in setup.cfg

## Testing
- `flake8 .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6875f9e855ac832f8c701ffa30fd32be