### PR TITLE
Remove direct schema calls in steps

### DIFF
--- a/tests/data_processing/test_feature_engineer.py
+++ b/tests/data_processing/test_feature_engineer.py
@@ -1,13 +1,15 @@
 import unittest
 import pandas as pd
 from zxq.pipeline.steps.feature_engineer import FeatureEngineer
+from zxq.pipeline.steps.schema_validator import SchemaValidatorStep
 
 
 class TestFeatureEngineer(unittest.TestCase):
     def test_feature_engineer(self):
         engineer = FeatureEngineer(features_to_create=['moving_average'])
+        wrapped = SchemaValidatorStep(engineer)
         df = pd.DataFrame({'close': [1, 2, 3, 4, 5, 6]})
-        processed_df = engineer.process(df)
+        processed_df = wrapped.process(df)
         self.assertIn('moving_average', processed_df.columns)
         self.assertTrue(pd.isna(processed_df['moving_average'].iloc[3]))
         self.assertEqual(processed_df['moving_average'].iloc[4], 3)

--- a/tests/data_processing/test_missing_value_handler.py
+++ b/tests/data_processing/test_missing_value_handler.py
@@ -2,25 +2,29 @@ import unittest
 import pandas as pd
 import numpy as np
 from zxq.pipeline.steps.missing_value_handler import MissingValueHandler
+from zxq.pipeline.steps.schema_validator import SchemaValidatorStep
 
 
 class TestMissingValueHandler(unittest.TestCase):
     def test_fill(self):
         handler = MissingValueHandler(strategy='fill', fill_value=0)
+        wrapped = SchemaValidatorStep(handler)
         df = pd.DataFrame({'a': [1, np.nan]})
-        processed_df = handler.process(df)
+        processed_df = wrapped.process(df)
         self.assertEqual(processed_df['a'].iloc[1], 0)
 
     def test_dropna(self):
         handler = MissingValueHandler(strategy='dropna')
+        wrapped = SchemaValidatorStep(handler)
         df = pd.DataFrame({'a': [1, np.nan]})
-        processed_df = handler.process(df)
+        processed_df = wrapped.process(df)
         self.assertEqual(len(processed_df), 1)
 
     def test_interpolate(self):
         handler = MissingValueHandler(strategy='interpolate')
+        wrapped = SchemaValidatorStep(handler)
         df = pd.DataFrame({'a': [1, np.nan, 3]})
-        processed_df = handler.process(df)
+        processed_df = wrapped.process(df)
         self.assertEqual(processed_df['a'].iloc[1], 2)
 
 

--- a/tests/data_processing/test_time_aligner.py
+++ b/tests/data_processing/test_time_aligner.py
@@ -1,20 +1,30 @@
 import unittest
 import pandas as pd
+from pandera.errors import SchemaError
 from zxq.pipeline.steps.time_aligner import TimeAligner
+from zxq.pipeline.steps.schema_validator import SchemaValidatorStep
 
 
 class TestTimeAligner(unittest.TestCase):
     def test_time_aligner(self):
         aligner = TimeAligner(resample_rule='1T', time_column='timestamp')
+        wrapped = SchemaValidatorStep(aligner)
         df = pd.DataFrame({
             'timestamp': pd.to_datetime(
                 ['2022-01-01 00:00:00', '2022-01-01 00:00:30']
             ),
             'value': [1, 2],
         })
-        processed_df = aligner.process(df)
+        processed_df = wrapped.process(df)
         self.assertEqual(len(processed_df), 1)
         self.assertEqual(processed_df['value'].iloc[0], 1.5)
+
+    def test_invalid_timestamp(self):
+        aligner = TimeAligner(resample_rule='1T', time_column='timestamp')
+        wrapped = SchemaValidatorStep(aligner)
+        df = pd.DataFrame({'timestamp': ['not a date'], 'value': [1]})
+        with self.assertRaises(SchemaError):
+            wrapped.process(df)
 
 
 if __name__ == '__main__':

--- a/zxq/pipeline/steps/data_cleanser.py
+++ b/zxq/pipeline/steps/data_cleanser.py
@@ -33,7 +33,6 @@ class DataCleanser(PipelineStep):
         Returns:
             The cleaned DataFrame.
         """
-        df = self._validate_input(df)
         processed_df = df.copy()
 
         if self.remove_outliers:
@@ -48,4 +47,4 @@ class DataCleanser(PipelineStep):
                     & (processed_df[column] <= upper_bound)
                 ]
 
-        return self._validate_output(processed_df)
+        return processed_df

--- a/zxq/pipeline/steps/feature_engineer.py
+++ b/zxq/pipeline/steps/feature_engineer.py
@@ -28,7 +28,6 @@ class FeatureEngineer(PipelineStep):
         Returns:
             The processed DataFrame.
         """
-        df = self._validate_input(df)
         processed_df = df.copy()
         for feature in self.features_to_create:
             if feature == 'moving_average':
@@ -37,4 +36,4 @@ class FeatureEngineer(PipelineStep):
                 )
             else:
                 raise ValueError(f"Unknown feature: {feature}")
-        return self._validate_output(processed_df)
+        return processed_df

--- a/zxq/pipeline/steps/missing_value_handler.py
+++ b/zxq/pipeline/steps/missing_value_handler.py
@@ -30,7 +30,6 @@ class MissingValueHandler(PipelineStep):
         Returns:
             The processed DataFrame.
         """
-        df = self._validate_input(df)
         if self.strategy == 'fill':
             processed_df = df.fillna(self.fill_value)
         elif self.strategy == 'dropna':
@@ -39,4 +38,4 @@ class MissingValueHandler(PipelineStep):
             processed_df = df.interpolate()
         else:
             raise ValueError(f"Unknown strategy: {self.strategy}")
-        return self._validate_output(processed_df)
+        return processed_df

--- a/zxq/pipeline/steps/time_aligner.py
+++ b/zxq/pipeline/steps/time_aligner.py
@@ -39,8 +39,7 @@ class TimeAligner(PipelineStep):
         Returns:
             The processed DataFrame.
         """
-        df = self._validate_input(df)
         df[self.time_column] = pd.to_datetime(df[self.time_column])
         df = df.set_index(self.time_column)
         processed_df = df.resample(self.resample_rule).mean()
-        return self._validate_output(processed_df.reset_index())
+        return processed_df.reset_index()


### PR DESCRIPTION
## Summary
- remove `_validate_input` and `_validate_output` calls from step implementations
- update unit tests to wrap steps in `SchemaValidatorStep` and ensure validation

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68760c368b98832faac1f43afafe59c4