### PR TITLE
Consolidate CLI with Typer

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,5 @@ extend-ignore = E203,W503
 packages = find:
 [options.entry_points]
 console_scripts =
-    zxq = zxq.cli:main
+    zxq = zxq.cli:app
 

--- a/tests/test_zxq_cli.py
+++ b/tests/test_zxq_cli.py
@@ -21,3 +21,36 @@ def test_audit_trace(tmp_path):
     result = runner.invoke(app, ["audit", "trace", "tbl", "--db", str(db_path)])
     assert result.exit_code == 0
     assert "tbl" in result.stdout
+
+
+def test_storage_migrate_dry_run(tmp_path):
+    db_path = tmp_path / "cat.db"
+    catalog = Catalog(db_path=str(db_path))
+    catalog.upsert(
+        CatalogEntry(
+            table_name="tbl",
+            version=1,
+            tier="hot",
+            location="hot",
+            schema_hash="h",
+            partition_keys="",
+        )
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "storage",
+            "migrate",
+            "--table",
+            "tbl",
+            "--to",
+            "warm",
+            "--db",
+            str(db_path),
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "預計將 tbl 從 hot 移至 warm" in result.stdout

--- a/zxq/__init__.py
+++ b/zxq/__init__.py
@@ -1,6 +1,5 @@
 """ZXQuant 工具集。"""
 
 from .cli import app
-from .__main__ import main
 
-__all__ = ["app", "main"]
+__all__ = ["app"]

--- a/zxq/__main__.py
+++ b/zxq/__main__.py
@@ -1,40 +1,5 @@
-"""zxq 指令列工具。"""
-
-import argparse
-from data_storage import HybridStorageManager
-
-
-def _cmd_storage_migrate(args: argparse.Namespace) -> None:
-    manager = HybridStorageManager()
-    entry = manager.catalog.get(args.table)
-    if entry is None:
-        raise SystemExit(f"找不到資料表 {args.table}")
-    if args.dry_run:
-        print(f"預計將 {args.table} 從 {entry.tier} 移至 {args.to}")
-    else:
-        manager.migrate(args.table, entry.tier, args.to)
-        print(f"已將 {args.table} 從 {entry.tier} 移至 {args.to}")
-
-
-def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(prog="zxq")
-    subparsers = parser.add_subparsers(dest="command")
-
-    storage_parser = subparsers.add_parser("storage")
-    storage_sub = storage_parser.add_subparsers(dest="action")
-
-    migrate_parser = storage_sub.add_parser("migrate")
-    migrate_parser.add_argument("--table", required=True)
-    migrate_parser.add_argument("--to", required=True, choices=["hot", "warm", "cold"])
-    migrate_parser.add_argument("--dry-run", action="store_true")
-    migrate_parser.set_defaults(func=_cmd_storage_migrate)
-
-    args = parser.parse_args(argv)
-    if hasattr(args, "func"):
-        args.func(args)
-    else:
-        parser.print_help()
-
+"""ZXQ 指令列入口。"""
+from .cli import app
 
 if __name__ == "__main__":
-    main()
+    app()

--- a/zxq/cli.py
+++ b/zxq/cli.py
@@ -1,12 +1,47 @@
 import typer
-import argparse
+from pathlib import Path
 from data_processing.cross_validation import walk_forward_split
-from data_storage import Catalog, CatalogEntry
+from data_storage import Catalog, CatalogEntry, HybridStorageManager
+import shutil
+
+SNAPSHOT_DIR = Path("snapshots")
+RESTORE_DIR = Path("restored")
+
+
+def restore_snapshot(snapshot: Path) -> None:
+    """還原指定快照檔案。"""
+    if not snapshot.exists():
+        raise FileNotFoundError(snapshot)
+    RESTORE_DIR.mkdir(exist_ok=True)
+    shutil.unpack_archive(str(snapshot), str(RESTORE_DIR))
+
+
+def verify_latest() -> None:
+    """尋找並還原最新的快照。"""
+    snapshots = sorted(
+        SNAPSHOT_DIR.glob("*.zip"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not snapshots:
+        typer.echo("找不到任何快照")
+        return
+    latest = snapshots[0]
+    typer.echo(f"還原 {latest.name}...")
+    restore_snapshot(latest)
+    typer.echo("還原完成")
+
 
 app = typer.Typer(help="ZXQuant CLI 工具")
 
 audit_app = typer.Typer(help="稽核相關指令")
 app.add_typer(audit_app, name="audit")
+
+storage_app = typer.Typer(help="儲存相關指令")
+app.add_typer(storage_app, name="storage")
+
+backup_app = typer.Typer(help="備份還原指令")
+app.add_typer(backup_app, name="backup")
 
 
 @audit_app.command()
@@ -25,38 +60,48 @@ def trace(table: str, db: str = ":memory:") -> None:
     typer.echo(msg)
 
 
+@app.command()
+def walk_forward(
+    samples: int,
+    train_size: int,
+    test_size: int,
+    step_size: int,
+) -> None:
+    """Walk-Forward 資料切分。"""
+    for train_idx, test_idx in walk_forward_split(
+        samples, train_size, test_size, step_size
+    ):
+        typer.echo(f"{train_idx} {test_idx}")
+
+
+@storage_app.command()
+def migrate(
+    table: str = typer.Option(..., "--table", help="要移動的資料表"),
+    to: str = typer.Option(..., "--to", help="目標層級"),
+    db: str = typer.Option(":memory:", "--db", help="Catalog 位置"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="僅顯示預計行動"),
+) -> None:
+    """移動資料表至指定層級。"""
+    manager = HybridStorageManager(catalog=Catalog(db_path=db))
+    entry = manager.catalog.get(table)
+    if entry is None:
+        typer.echo(f"找不到資料表 {table}")
+        raise typer.Exit(code=1)
+    if dry_run:
+        typer.echo(f"預計將 {table} 從 {entry.tier} 移至 {to}")
+    else:
+        manager.migrate(table, entry.tier, to)
+        typer.echo(f"已將 {table} 從 {entry.tier} 移至 {to}")
+
+
+@backup_app.command()
+def verify(latest: bool = False) -> None:
+    """驗證或還原備份。"""
+    if latest:
+        verify_latest()
+    else:
+        typer.echo("請使用 --latest 參數")
+
+
 if __name__ == "__main__":
     app()
-
-
-def _cmd_walk_forward(args: argparse.Namespace) -> None:
-    """執行 Walk-Forward 切分並列印索引。"""
-    for train_idx, test_idx in walk_forward_split(
-        args.samples,
-        args.train_size,
-        args.test_size,
-        args.step_size,
-    ):
-        print(train_idx, test_idx)
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser(prog="zxq")
-    subparsers = parser.add_subparsers(dest="command")
-
-    wf = subparsers.add_parser("walk-forward", help="Walk-Forward 資料切分")
-    wf.add_argument("samples", type=int, help="總樣本數")
-    wf.add_argument("train_size", type=int, help="訓練集大小")
-    wf.add_argument("test_size", type=int, help="測試集大小")
-    wf.add_argument("step_size", type=int, help="步進大小")
-    wf.set_defaults(func=_cmd_walk_forward)
-
-    args = parser.parse_args()
-    if hasattr(args, "func"):
-        args.func(args)
-    else:
-        parser.print_help()
-
-
-if __name__ == "__main__":
-    main()

--- a/zxq_cli.py
+++ b/zxq_cli.py
@@ -1,64 +1,6 @@
 #!/usr/bin/env python
-"""ZXQ 指令列工具。"""
-
-from __future__ import annotations
-
-import argparse
-from pathlib import Path
-import shutil
-
-SNAPSHOT_DIR = Path("snapshots")
-RESTORE_DIR = Path("restored")
-
-
-def restore_snapshot(snapshot: Path) -> None:
-    """還原指定快照檔案。"""
-    if not snapshot.exists():
-        raise FileNotFoundError(snapshot)
-    RESTORE_DIR.mkdir(exist_ok=True)
-    shutil.unpack_archive(str(snapshot), str(RESTORE_DIR))
-
-
-def verify_latest() -> None:
-    """尋找並還原最新的快照。"""
-    snapshots = sorted(
-        SNAPSHOT_DIR.glob("*.zip"),
-        key=lambda p: p.stat().st_mtime,
-        reverse=True,
-    )
-    if not snapshots:
-        print("找不到任何快照")
-        return
-    latest = snapshots[0]
-    print(f"還原 {latest.name}...")
-    restore_snapshot(latest)
-    print("還原完成")
-
-
-def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(prog="zxq")
-    subparsers = parser.add_subparsers(dest="command")
-
-    backup_parser = subparsers.add_parser("backup")
-    backup_sub = backup_parser.add_subparsers(dest="subcommand")
-
-    verify_parser = backup_sub.add_parser("verify")
-    verify_parser.add_argument(
-        "--latest",
-        action="store_true",
-        help="還原最新快照",
-    )
-
-    args = parser.parse_args(argv)
-
-    if args.command == "backup" and args.subcommand == "verify":
-        if args.latest:
-            verify_latest()
-        else:
-            verify_parser.print_help()
-    else:
-        parser.print_help()
-
+"""ZXQ 指令列入口。"""
+from zxq.cli import app
 
 if __name__ == "__main__":
-    main()
+    app()


### PR DESCRIPTION
## Summary
- consolidate zxq command line interface to Typer
- expose migrate and backup commands through Typer
- update entry point in setup.cfg
- adjust tests for new CLI options

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68760c36bff8832fba07de8218a479ae