### PR TITLE
Add IncrementalRunner for streaming pipelines

### DIFF
--- a/data_processing/incremental_runner.py
+++ b/data_processing/incremental_runner.py
@@ -1,0 +1,49 @@
+"""增量處理 Runner，從 Kafka/Redpanda 讀取資料並即時應用 Pipeline。
+"""
+from __future__ import annotations
+
+import pandas as pd
+from kafka import KafkaConsumer
+
+from data_processing.pipeline import Pipeline
+from data_storage.storage_backend import HybridStorageManager
+
+
+class IncrementalRunner:
+    """持續消費 Kafka 訊息並逐批處理。"""
+
+    def __init__(
+        self,
+        pipeline: Pipeline,
+        topics: list[str],
+        *,
+        bootstrap_servers: str = "localhost:9092",
+        group_id: str = "incremental_runner",
+        manager: HybridStorageManager | None = None,
+        result_table: str = "incremental_results",
+    ) -> None:
+        self.pipeline = pipeline
+        self.consumer = KafkaConsumer(
+            *topics,
+            bootstrap_servers=bootstrap_servers,
+            group_id=group_id,
+            value_deserializer=lambda m: pd.read_json(m.decode("utf-8")),
+            auto_offset_reset="earliest",
+            enable_auto_commit=True,
+        )
+        self.manager = manager or HybridStorageManager()
+        self.result_table = result_table
+
+    def run_forever(self, num_workers: int = 1) -> None:
+        """持續接收資料並寫入處理結果。"""
+        for msg in self.consumer:
+            df: pd.DataFrame = msg.value
+            processed = self.pipeline.process(df, num_workers=num_workers)
+            self.manager.write(processed, self.result_table, tier="hot")
+
+    def read_results(self) -> pd.DataFrame:
+        """讀取目前累積的結果。"""
+        try:
+            return self.manager.read(self.result_table)
+        except KeyError:
+            return pd.DataFrame()

--- a/docs/incremental_runner.md
+++ b/docs/incremental_runner.md
@@ -1,0 +1,29 @@
+# 增量處理 Runner
+
+`IncrementalRunner` 允許從 Kafka/Redpanda 主題持續讀取資料並依序套用 `PipelineStep`。每批資料處理後會寫入 `HybridStorageManager` 以供即時回測使用。
+
+## 建立與啟動
+```python
+from data_processing.pipeline import Pipeline
+from data_processing.incremental_runner import IncrementalRunner
+from zxq.pipeline.steps.data_cleanser import DataCleanser
+
+pipeline = Pipeline([DataCleanser()])
+runner = IncrementalRunner(
+    pipeline,
+    topics=["prices"],
+    bootstrap_servers="localhost:9092",
+    group_id="backtest",
+    result_table="prices_clean"
+)
+runner.run_forever()
+```
+
+## 讀取結果
+```python
+from data_storage.storage_backend import HybridStorageManager
+
+manager = HybridStorageManager()
+latest = manager.read("prices_clean")
+print(latest.tail())
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ nav:
   - 指南:
       - 多層級儲存: data_storage.md
       - 監控與警報設定: monitoring.md
+      - 增量處理 Runner: incremental_runner.md
   - API:
       - Data Storage: reference/data_storage.md
       - Data Ingestion: reference/data_ingestion.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ duckdb
 psycopg[binary]
 boto3
 pyarrow
+kafka-python


### PR DESCRIPTION
## Summary
- support Kafka streaming with `IncrementalRunner`
- document incremental processing setup
- include docs in mkdocs navigation
- add kafka-python dependency

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876665c5e34832fba54e02a5bf410dd