### PR TITLE
Add notifier framework

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from data_storage import HybridStorageManager, Catalog, check_drift
+from utils.notify import SlackNotifier
 
 
 def test_catalog_updates_on_write():
@@ -44,7 +45,8 @@ def test_check_drift(monkeypatch):
         messages.append(json["text"])
 
     monkeypatch.setattr("httpx.post", fake_post)
-    mismatched = check_drift(manager, webhook_url="http://example.com")
+    notifier = SlackNotifier("http://example.com")
+    mismatched = check_drift(manager, notifier=notifier)
 
     assert "tbl3" in mismatched
     assert messages

--- a/tests/test_notifiers.py
+++ b/tests/test_notifiers.py
@@ -1,0 +1,53 @@
+import smtplib
+import httpx
+from utils.notify import SlackNotifier, PagerDutyNotifier, EmailNotifier
+
+
+def test_slack_notifier(monkeypatch):
+    messages = []
+
+    def fake_post(url, json):
+        messages.append((url, json))
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    notifier = SlackNotifier("http://hook")
+    notifier.send("hello")
+    assert messages and messages[0][1]["text"] == "hello"
+
+
+def test_pagerduty_notifier(monkeypatch):
+    posts = []
+
+    def fake_post(url, json):
+        posts.append((url, json))
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    notifier = PagerDutyNotifier("RK")
+    notifier.send("alert")
+    assert posts
+    assert posts[0][1]["payload"]["summary"] == "alert"
+
+
+def test_email_notifier(monkeypatch):
+    sent = {}
+
+    class FakeSMTP:
+        def __init__(self, server):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def sendmail(self, from_addr, to_addrs, msg):
+            sent["from"] = from_addr
+            sent["to"] = to_addrs
+            sent["msg"] = msg
+
+    monkeypatch.setattr(smtplib, "SMTP", FakeSMTP)
+    notifier = EmailNotifier("a@b.com", "c@d.com")
+    notifier.send("msg")
+    assert sent["to"] == ["c@d.com"]
+    assert sent["msg"] == "msg"

--- a/utils/notify.py
+++ b/utils/notify.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import httpx
+import smtplib
+
+
+
+class Notifier(ABC):
+    """通知介面，所有通知方式皆應實作 send 方法。"""
+
+    @abstractmethod
+    def send(self, message: str) -> None:
+        """傳送訊息。"""
+        raise NotImplementedError
+
+
+class SlackNotifier(Notifier):
+    """透過 Slack webhook 傳送訊息。"""
+
+    def __init__(self, webhook_url: str | None) -> None:
+        self.webhook_url = webhook_url
+
+    def send(self, message: str) -> None:
+        if not self.webhook_url:
+            return
+        try:
+            httpx.post(self.webhook_url, json={"text": message})
+        except Exception:
+            pass
+
+
+class PagerDutyNotifier(Notifier):
+    """透過 PagerDuty 事件 API 傳送警報。"""
+
+    def __init__(self, routing_key: str | None) -> None:
+        self.routing_key = routing_key
+        self.url = "https://events.pagerduty.com/v2/enqueue"
+
+    def send(self, message: str) -> None:
+        if not self.routing_key:
+            return
+        payload = {
+            "routing_key": self.routing_key,
+            "event_action": "trigger",
+            "payload": {
+                "summary": message,
+                "source": "data-fetcher",
+                "severity": "error",
+            },
+        }
+        try:
+            httpx.post(self.url, json=payload)
+        except Exception:
+            pass
+
+
+class EmailNotifier(Notifier):
+    """以 SMTP 發送電子郵件。"""
+
+    def __init__(
+        self, from_addr: str, to_addr: str, smtp_server: str = "localhost"
+    ) -> None:
+        self.from_addr = from_addr
+        self.to_addr = to_addr
+        self.smtp_server = smtp_server
+
+    def send(self, message: str) -> None:
+        try:
+            with smtplib.SMTP(self.smtp_server) as smtp:
+                smtp.sendmail(self.from_addr, [self.to_addr], message)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- add `Notifier` base class and Slack/PagerDuty/Email implementations
- inject notifier into `check_drift` and related pipeline
- provide unit tests for notifier classes and update catalog drift test

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68766f24adb8832f8c48c42fe942ecfe