### PR TITLE
Add migration and drift tests

### DIFF
--- a/tests/test_cold_to_warm_migration.py
+++ b/tests/test_cold_to_warm_migration.py
@@ -1,0 +1,30 @@
+import pandas as pd
+from data_storage import HybridStorageManager, Catalog
+from utils.notify import SlackNotifier, PagerDutyNotifier
+
+
+def test_cold_to_warm_migration_preserves_data(monkeypatch):
+    # mock notifier network calls
+    messages = []
+
+    def fake_post(url, json):
+        messages.append(json)
+
+    monkeypatch.setattr("httpx.post", fake_post)
+
+    catalog = Catalog()
+    manager = HybridStorageManager(catalog=catalog)
+
+    df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    manager.write(df, "cold_tbl", tier="cold")
+
+    manager.migrate("cold_tbl", "cold", "warm")
+    result = manager.read("cold_tbl", tiers=["warm"])
+
+    pd.testing.assert_frame_equal(result, df)
+
+    # send notifications (should use mocked httpx.post)
+    SlackNotifier("http://hook").send("migrated")
+    PagerDutyNotifier("rk").send("migrated")
+
+    assert messages

--- a/tests/test_schema_drift.py
+++ b/tests/test_schema_drift.py
@@ -1,0 +1,27 @@
+import pandas as pd
+from data_storage import HybridStorageManager, Catalog, check_drift
+from utils.notify import SlackNotifier
+
+
+def test_column_type_change_triggers_notification(monkeypatch):
+    catalog = Catalog()
+    manager = HybridStorageManager(catalog=catalog)
+    df = pd.DataFrame({"a": [1]})
+    manager.write(df, "tbl", tier="hot")
+
+    # simulate schema drift by altering column type without updating catalog
+    new_df = pd.DataFrame({"a": ["1"]})
+    manager.hot_store.delete("tbl")
+    manager.hot_store.write(new_df, "tbl")
+
+    messages = []
+
+    def fake_post(url, json):
+        messages.append(json["text"])
+
+    monkeypatch.setattr("httpx.post", fake_post)
+    notifier = SlackNotifier("http://hook")
+    mismatched = check_drift(manager, notifier=notifier)
+
+    assert "tbl" in mismatched
+    assert messages and "tbl" in messages[0]


### PR DESCRIPTION
## Summary
- add tests for schema drift notifications
- add tests for cold to warm data migration integrity
- mock Slack and PagerDuty in new tests

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876741f0e70832f94f5fab30bc9127c